### PR TITLE
Peerplays authentication

### DIFF
--- a/packages/peerplays/lib/peerplays.js
+++ b/packages/peerplays/lib/peerplays.js
@@ -360,6 +360,32 @@ export default class PPY extends Plugin {
   }
 
   /**
+   * peerplaysjs-lib.Login will generate keys from provided data and compare them with the ones pulled from the
+   * Peerplays blockchain (`userPubKeys`).
+   *
+   * @param {String} username - The login username to associate with the account to be registered.
+   * @param {String} password - The login password to associate with the account to be registered.
+   * @param {String} prefix - Optional prefix.
+   * @returns {Boolean}
+   */
+  async authUser(username, password, prefix = 'PPY') {
+    // Ensure the Login class has the correct roles configured.
+    const roles = ['owner', 'active', 'memo'];
+    Login.setRoles(roles);
+
+    const userPubKeys = await getAccountKeys(username);
+
+    const user = {
+      accountName: username,
+      password,
+      auths: userPubKeys,
+    };
+
+    const authed = Login.checkKeys(user, prefix);
+    return authed;
+  }
+
+  /**
    * Requests from Peerplays blockchain for account data object.
    *
    * @param {String} accountNameOrId - The Peerplays account username to request data for.

--- a/packages/peerplays/lib/peerplays.js
+++ b/packages/peerplays/lib/peerplays.js
@@ -33,6 +33,8 @@ const methods = {
   BROADCAST: 'broadcast_transaction_with_callback',
 };
 
+const roles = ['owner', 'active', 'memo'];
+
 const MAINNET_CHAIN_ID = '6b6b5f0ce7a36d323768e534f3edb41c6d6332a541a95725b98e28d140850134'; // alice
 const TESTNET_CHAIN_ID = 'b3f7fe1e5ad0d2deca40a626a4404524f78e65c3a48137551c33ea4e7c365672'; // beatrice
 
@@ -370,7 +372,6 @@ export default class PPY extends Plugin {
    */
   async authUser(username, password, prefix = 'PPY') {
     // Ensure the Login class has the correct roles configured.
-    const roles = ['owner', 'active', 'memo'];
     Login.setRoles(roles);
 
     const userPubKeys = await getAccountKeys(username);
@@ -381,6 +382,7 @@ export default class PPY extends Plugin {
       auths: userPubKeys,
     };
 
+    // TODO: modify this such that the Scatter UI has the data it requires to import an existing account. Likely will require to generate keys and return them to something
     const authed = Login.checkKeys(user, prefix);
     return authed;
   }


### PR DESCRIPTION
Tentative completion for peerplays account "import". Still requires changes as we are unsure exactly what format the Scatter wallet is expecting for keys to be imported. The function added with this PR will allow provision of a username and password which is then used to generate keys to authorize a Peerplays account. If authorized, the private keys generated can be used as they match up with the account that was requesting authorization.

Closes #21 